### PR TITLE
Adding unit tests

### DIFF
--- a/Assets/CursorControl/Tests.meta
+++ b/Assets/CursorControl/Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c6ecd7ea06982134980c29442baf8145
+folderAsset: yes
+timeCreated: 1470724568
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CursorControl/Tests/Unit Tests.meta
+++ b/Assets/CursorControl/Tests/Unit Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 532405bcc9d329c4ba283c7d6a3dd9aa
+folderAsset: yes
+timeCreated: 1470756824
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CursorControl/Tests/Unit Tests/Editor.meta
+++ b/Assets/CursorControl/Tests/Unit Tests/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 22ecd9e060d93e74187067da4b03d977
+folderAsset: yes
+timeCreated: 1470724577
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CursorControl/Tests/Unit Tests/Editor/CursorControlTest.cs
+++ b/Assets/CursorControl/Tests/Unit Tests/Editor/CursorControlTest.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+using NUnit.Framework;
+
+/// <summary>
+/// Unit tests for CursorControl class
+/// </summary>
+public class CursorControlTest
+{
+
+    /// <summary>
+    /// Tests GetGlobalCursorPos() and SetGlobalCursorPos()
+    /// </summary>
+    [Test]
+    public void GlobalPosTest()
+    {
+        Vector2 pos = new Vector2(100, 200);
+        CursorControl.SetGlobalCursorPos(pos);
+        Assert.AreEqual(pos, CursorControl.GetGlobalCursorPos());
+    }
+
+    /// <summary>
+    /// Tests SetLocalCursorPos()
+    /// </summary>
+    /// <remarks>
+    /// This test should pass in theory. However, when using the Unity editor test runner,
+    /// the game window is not in focus and therefore Input.mousePosition does not update.
+    /// Therefore, I have left the test in but commented it out.
+    /// </remarks>
+    //[Test]
+    //public void LocalPosTest()
+    //{
+    //    Vector2 pos = new Vector2(100, 200);
+    //    CursorControl.SetLocalCursorPos(pos);
+    //    Assert.AreEqual(pos, (Vector2)Input.mousePosition);
+    //}
+}

--- a/Assets/CursorControl/Tests/Unit Tests/Editor/CursorControlTest.cs.meta
+++ b/Assets/CursorControl/Tests/Unit Tests/Editor/CursorControlTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cc4930827c05ba04db3bd6d03690cd08
+timeCreated: 1470724589
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #3 

Added unit test to cover SetGlobalCursorPos() and GetGlobalCursorPos().

Unit test that covers SetLocalCursorPos() is commented out because it doesn't pass.

It should pass in theory. However, when using the Unity editor test runner, the game window is not in focus and therefore Input.mousePosition does not update. Therefore, I have left the test in but commented it out.
