### PR TITLE
Added TestFixtureSetUp and TestFixtureTearDown to NUnit tests

### DIFF
--- a/Assets/CursorControl/Tests/Unit Tests/Editor/CursorControlTest.cs
+++ b/Assets/CursorControl/Tests/Unit Tests/Editor/CursorControlTest.cs
@@ -7,8 +7,32 @@ namespace UnityCursorControl
     /// <summary>
     /// Unit tests for CursorControl class
     /// </summary>
+    [TestFixture]
     public class CursorControlTest
     {
+
+        /// <summary>
+        /// Stores the initial cursor position
+        /// </summary>
+        private Vector2 _cursorPos;
+
+        /// <summary>
+        /// Remembers the cursor position before the tests are run
+        /// </summary>
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            _cursorPos = CursorControl.GetGlobalCursorPos();
+        }
+
+        /// <summary>
+        /// Sets the cursor position back to its original position after the tests are run
+        /// </summary>
+        [TestFixtureTearDown]
+        public void TestFixtureTearDown()
+        {
+            CursorControl.SetGlobalCursorPos(_cursorPos);
+        }
 
         /// <summary>
         /// Tests GetGlobalCursorPos() and SetGlobalCursorPos()


### PR DESCRIPTION
The test fixture moves the mouse cursor back to its original position after the tests are run, in order to improve the user experience of the tester.
